### PR TITLE
exchange order of --format csv,noheader and --query-gpu={} in query_gpu funtion

### DIFF
--- a/scramble4gpu.py
+++ b/scramble4gpu.py
@@ -49,7 +49,7 @@ def parse(qargs, results):
 
 def query_gpu():
     qargs = ['index', 'memory.free', 'memory.total']
-    cmd = 'nvidia-smi --query-gpu={} --format=csv, noheader'.format(','.join(qargs))
+    cmd = 'nvidia-smi --format=csv,noheader --query-gpu={}'.format(','.join(qargs))
     results = os.popen(cmd).readlines()
 
     return parse(qargs, results), results[0].strip()


### PR DESCRIPTION
Hi, thank you for your great work!

On my machine, function query_gpu will cause an error 

ERROR: Option noheader is not recognized. Please run 'nvidia-smi -h' for help.

after checking the [documentation of `nvidia-smi`](https://developer.download.nvidia.com/compute/DCGM/docs/nvidia-smi-367.38.pdf). I found that the position of --format and --query-gpu should exchange